### PR TITLE
Player movement

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -1,0 +1,6 @@
+﻿{
+  "version": "1.0",
+  "components": [
+    "Microsoft.VisualStudio.Workload.ManagedGame"
+  ]
+}

--- a/Assets/Materials.meta
+++ b/Assets/Materials.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0fc34721fe7550f4198e53621610d0ca
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Materials/Player Physics.physicsMaterial2D
+++ b/Assets/Materials/Player Physics.physicsMaterial2D
@@ -1,0 +1,11 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!62 &6200000
+PhysicsMaterial2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Player Physics
+  friction: 0
+  bounciness: 0

--- a/Assets/Materials/Player Physics.physicsMaterial2D.meta
+++ b/Assets/Materials/Player Physics.physicsMaterial2D.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0d6b27ab754232a4ab186923501e0be9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 6200000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/PlayerTesting.unity
+++ b/Assets/Scenes/PlayerTesting.unity
@@ -179,6 +179,9 @@ GameObject:
   - component: {fileID: 821923736}
   - component: {fileID: 821923738}
   - component: {fileID: 821923737}
+  - component: {fileID: 821923741}
+  - component: {fileID: 821923740}
+  - component: {fileID: 821923739}
   m_Layer: 0
   m_Name: Tilemap
   m_TagString: Untagged
@@ -792,6 +795,115 @@ Tilemap:
     e31: 0
     e32: 0
     e33: 1
+--- !u!66 &821923739
+CompositeCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 821923735}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_GeometryType: 0
+  m_GenerationType: 0
+  m_EdgeRadius: 0
+  m_ColliderPaths:
+  - m_Collider: {fileID: 821923741}
+    m_ColliderPaths:
+    - - X: 120000000
+        Y: 10000000
+      - X: 70000000
+        Y: 10000000
+      - X: 70000000
+        Y: 0
+      - X: 120000000
+        Y: 0
+    - - X: -80000000
+        Y: 10000000
+      - X: -130000000
+        Y: 10000000
+      - X: -130000000
+        Y: 0
+      - X: -80000000
+        Y: 0
+    - - X: 40000000
+        Y: -30000000
+      - X: -40000000
+        Y: -30000000
+      - X: -40000000
+        Y: -40000000
+      - X: 40000000
+        Y: -40000000
+    - - X: 150000000
+        Y: -70000000
+      - X: -150000000
+        Y: -70000000
+      - X: -150000000
+        Y: -80000000
+      - X: 150000000
+        Y: -80000000
+  m_CompositePaths:
+    m_Paths:
+    - - {x: 11.99997, y: 0}
+      - {x: 11.99997, y: 1}
+      - {x: 7, y: 0.99997073}
+      - {x: 7.0000296, y: 0}
+    - - {x: -8.00003, y: 0}
+      - {x: -8.00003, y: 1}
+      - {x: -13, y: 0.99997073}
+      - {x: -12.99997, y: 0}
+    - - {x: 3.999971, y: -4}
+      - {x: 3.999971, y: -3}
+      - {x: -4, y: -3.0000293}
+      - {x: -3.999971, y: -4}
+    - - {x: 14.999971, y: -8}
+      - {x: 14.999971, y: -7}
+      - {x: -15, y: -7.0000296}
+      - {x: -14.999971, y: -8}
+  m_VertexDistance: 0.0005
+  m_OffsetDistance: 0.00005
+--- !u!50 &821923740
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 821923735}
+  m_BodyType: 1
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!19719996 &821923741
+TilemapCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 821923735}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 1
+  m_Offset: {x: 0, y: 0}
+  m_MaximumTileChangeCount: 1000
+  m_ExtrusionFactor: 0.00001
 --- !u!1 &919455095
 GameObject:
   m_ObjectHideFlags: 0
@@ -886,6 +998,8 @@ GameObject:
   m_Component:
   - component: {fileID: 1081541314}
   - component: {fileID: 1081541313}
+  - component: {fileID: 1081541315}
+  - component: {fileID: 1081541316}
   m_Layer: 0
   m_Name: Player
   m_TagString: Untagged
@@ -953,10 +1067,47 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1081541312}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: -1.96, z: 0}
+  m_LocalPosition: {x: 0, y: -1.35, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!70 &1081541315
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1081541312}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.033714116, y: -0.38771188}
+  m_Size: {x: 0.7751436, y: 1.2245762}
+  m_Direction: 0
+--- !u!50 &1081541316
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1081541312}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 4

--- a/Assets/Scenes/PlayerTesting.unity
+++ b/Assets/Scenes/PlayerTesting.unity
@@ -1084,7 +1084,7 @@ CapsuleCollider2D:
   m_GameObject: {fileID: 1081541312}
   m_Enabled: 1
   m_Density: 1
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 6200000, guid: 0d6b27ab754232a4ab186923501e0be9, type: 2}
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
@@ -1106,11 +1106,11 @@ Rigidbody2D:
   m_Mass: 1
   m_LinearDrag: 0
   m_AngularDrag: 0.05
-  m_GravityScale: 1
+  m_GravityScale: 5
   m_Material: {fileID: 0}
   m_Interpolate: 0
   m_SleepingMode: 1
-  m_CollisionDetection: 0
+  m_CollisionDetection: 1
   m_Constraints: 4
 --- !u!114 &1081541317
 MonoBehaviour:

--- a/Assets/Scenes/PlayerTesting.unity
+++ b/Assets/Scenes/PlayerTesting.unity
@@ -1000,6 +1000,7 @@ GameObject:
   - component: {fileID: 1081541313}
   - component: {fileID: 1081541315}
   - component: {fileID: 1081541316}
+  - component: {fileID: 1081541317}
   m_Layer: 0
   m_Name: Player
   m_TagString: Untagged
@@ -1111,3 +1112,18 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 4
+--- !u!114 &1081541317
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1081541312}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 48d621395f533454abdee8011b542b78, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  moveSpeed: 10
+  jumpForce: 21
+  rigidBody2D: {fileID: 1081541316}

--- a/Assets/Scripts.meta
+++ b/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 859ee4eedafba2342ad9d2fff2413cc3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -16,6 +16,11 @@ public class PlayerController : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        rigidBody2D.velocity = new Vector2(Input.GetAxis("Horizontal") * moveSpeed, rigidBody2D.velocity.y);
+        rigidBody2D.velocity = new Vector2(Input.GetAxisRaw("Horizontal") * moveSpeed, rigidBody2D.velocity.y);
+
+        if (Input.GetButtonDown("Jump")) 
+        {
+            rigidBody2D.velocity = new Vector2(rigidBody2D.velocity.x, jumpForce);
+        }
     }
 }

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -1,0 +1,21 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerController : MonoBehaviour
+{
+    public float moveSpeed, jumpForce;
+    public Rigidbody2D rigidBody2D;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        rigidBody2D.velocity = new Vector2(Input.GetAxis("Horizontal") * moveSpeed, rigidBody2D.velocity.y);
+    }
+}

--- a/Assets/Scripts/PlayerController.cs.meta
+++ b/Assets/Scripts/PlayerController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 48d621395f533454abdee8011b542b78
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -3,7 +3,7 @@
     "com.unity.collab-proxy": "1.15.16",
     "com.unity.feature.2d": "1.0.0",
     "com.unity.ide.rider": "3.0.14",
-    "com.unity.ide.visualstudio": "2.0.15",
+    "com.unity.ide.visualstudio": "2.0.16",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.test-framework": "1.1.31",
     "com.unity.textmeshpro": "3.0.6",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -134,7 +134,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.visualstudio": {
-      "version": "2.0.15",
+      "version": "2.0.16",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/InputManager.asset
+++ b/ProjectSettings/InputManager.asset
@@ -485,3 +485,4 @@ InputManager:
     type: 2
     axis: 5
     joyNum: 0
+  m_UsePhysicalKeys: 0


### PR DESCRIPTION
- Add Colliders on Player and Tilemap
- Enable player movement on horizontal axis
- Fix edge collision issue by creating and adding a new material for the player
- Set the friction on new material to 0
- Change the collision detection mode to continuous to avoid the player sinking in the ground after falling from a jump
- Change the gravity scale from 1 to 5 to make the jump much more smoother